### PR TITLE
Wireframe rendering with depth animation and Catalyst Agent setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 .DS_Store
 *.local
 .claude/settings.local.json
+.claude/worktrees

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,12 @@
 # cc-web
 
 This project is managed by cc-web (a project configuration management app). It has assigned you ports 4100-4149. When you create any launch files or server configs, DO NOT use any ports outside of that range.
+
+# Catalyst Agent
+
+This project is managed by Catalyst Agent. Your dev server ports are defined in
+PORTS.LOCAL (auto-generated per worktree). Start the server with start.local.sh.
+If you need to change how the server is started, edit both start.sh (using __PORT_N__
+template vars) and start.local.sh (using real port numbers).
+If you need additional ports while making changes, add another entry to PORTS
+and PORTS.LOCAL.

--- a/PORTS
+++ b/PORTS
@@ -1,0 +1,1 @@
+__PORT_1__ - Vite dev server

--- a/src/animations.ts
+++ b/src/animations.ts
@@ -93,6 +93,7 @@ function randomRotationTarget(): RotationTarget {
 interface CycleState {
 	motionIndices: number[];
 	rotationTargets: RotationTarget[];
+	zOffsets: number[];
 	cycleColor: THREE.Color;
 	letterColors: THREE.Color[];
 	nextCycleColor: THREE.Color;
@@ -121,17 +122,22 @@ function pickUniqueColors(count: number): THREE.Color[] {
 	return colors;
 }
 
+const MAX_Z_OFFSET = 4; // moves letters from Z=0 towards camera at Z=12, ~50% larger at max
+
 function newCycleState(letterCount: number, cycleColor: THREE.Color): CycleState {
 	const motionIndices: number[] = [];
 	const rotationTargets: RotationTarget[] = [];
+	const zOffsets: number[] = [];
 	for (let i = 0; i < letterCount; i++) {
 		motionIndices.push(Math.floor(Math.random() * MOTION_FUNCTIONS.length));
 		rotationTargets.push(randomRotationTarget());
+		zOffsets.push(Math.random() * MAX_Z_OFFSET);
 	}
 
 	return {
 		motionIndices,
 		rotationTargets,
+		zOffsets,
 		cycleColor: cycleColor.clone(),
 		letterColors: pickUniqueColors(letterCount),
 		nextCycleColor: new THREE.Color(pickRandom(TARGET_PALETTE)),
@@ -178,7 +184,7 @@ export function updateLetters(letters: LetterMesh[], timeSec: number): void {
 			letter.mesh.position.set(
 				letter.homePosition.x + offset.x * envelope,
 				letter.homePosition.y + offset.y * envelope,
-				letter.homePosition.z + offset.z * envelope,
+				letter.homePosition.z + offset.z * envelope + cycleState.zOffsets[i] * envelope,
 			);
 
 			// Rotation

--- a/src/letters.ts
+++ b/src/letters.ts
@@ -51,6 +51,7 @@ export async function createLetters(scene: THREE.Scene): Promise<LetterMesh[]> {
 			color: BASE_COLOR,
 			roughness: 1,
 			metalness: 0,
+			wireframe: true,
 		});
 
 		const mesh = new THREE.Mesh(geometry, material);

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec npx vite --port __PORT_1__


### PR DESCRIPTION
## Summary
- Switch letter rendering to wireframe style
- Add random per-letter Z-offset animation (0-4 units towards camera) for depth effect, making letters appear up to ~50% larger at peak motion
- Set up Catalyst Agent with start.sh, PORTS, and CLAUDE.md config
- Add .claude/worktrees to .gitignore

## Test plan
- [ ] Verify letters render as wireframes
- [ ] Confirm letters move towards/away from camera with varying depths each cycle
- [ ] Check that `start.sh` runs the Vite dev server correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)