### PR TITLE
Serve site at taylorsteil.com

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+taylorsteil.com

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "vite";
 
 export default defineConfig({
-	base: "/taylorsteil.com/",
+	base: "/",
 });


### PR DESCRIPTION
## Summary
- Add CNAME file for GitHub Pages custom domain (`taylorsteil.com`)
- Change Vite base path from `/taylorsteil.com/` to `/` for root domain serving

## Test plan
- [ ] Verify GitHub Pages deploy succeeds
- [ ] Confirm taylorsteil.com resolves and serves the site
- [ ] Confirm HTTPS works after GitHub provisions the Let's Encrypt certificate

🤖 Generated with [Claude Code](https://claude.com/claude-code)